### PR TITLE
docs: add Related Resources section (ARC Raider Hub companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ---
 
+## Related Resources
+
+- [ARC Raider Hub](https://arcraiderhub.xyz/) — ARC Raiders weapon tier lists, extraction routes, augment guides, and raid strategies.
+
 ## License
 
 This project is licensed under the **Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License** ([CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)).


### PR DESCRIPTION
Thanks for building ARDB — a data/resource project is a natural place for a companion ARC Raiders guide hub.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [ARC Raider Hub](https://arcraiderhub.xyz/) — ARC Raiders weapon tier lists, extraction routes, augment guides, and raid strategies.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `before:## License`.)_